### PR TITLE
Improve direct messaging flow

### DIFF
--- a/backgroundscript.js
+++ b/backgroundscript.js
@@ -57,7 +57,7 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
                             hideGrowbot: true
                         });
                         chrome.tabs.sendMessage(tabId, {
-                            clickSomething: 'button:contains("Message")'
+                            clickSomething: 'button:contains("Message"), div[role="button"]:contains("Message")'
                         });
                         setTimeout(function() {
                             chrome.tabs.sendMessage(tabId, {

--- a/contentscript.js
+++ b/contentscript.js
@@ -7281,14 +7281,15 @@ function userUpdateListener() {
 
             if (request.sendDirectMessage) {
                 var msg = request.sendDirectMessage.text;
-                var box = $('textarea[placeholder="Message..."] , div[role="textbox"][contenteditable="true"]').first();
+                var box = $('textarea[placeholder="Message..."], textarea[placeholder="Message…"], div[role="textbox"][contenteditable="true"]').first();
                 if (box.length) {
                     if (box.is('textarea')) {
-                        box.val(msg);
+                        var nativeSetter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value').set;
+                        nativeSetter.call(box[0], msg);
                     } else {
-                        box.text(msg);
+                        box[0].textContent = msg;
                     }
-                    box.trigger('input');
+                    box[0].dispatchEvent(new Event('input', { bubbles: true }));
                     var btn = $('button[type="submit"], svg[aria-label="Send"]').last();
                     if (btn.length) {
                         if (btn.is('svg')) btn = btn.parent();


### PR DESCRIPTION
## Summary
- Update message button selector to support new Instagram layout
- Use native input events to populate and send direct messages more reliably

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f4cc939c08323a7928e74d01333bf