### PR TITLE
Reorganize navigation and improve layout

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -7,6 +7,74 @@
     {
         "message": "Automatic follow/unfollow/like with advanced filters, randomized timers, and more high-tech features."
     },
+    "AccountsQueueTab":
+    {
+        "message": "Accounts Queue"
+    },
+    "MediaQueueTab":
+    {
+        "message": "Media Queue"
+    },
+    "ActionsQueueTab":
+    {
+        "message": "Actions Queue"
+    },
+    "FiltersTab":
+    {
+        "message": "Filters"
+    },
+    "SettingsTab":
+    {
+        "message": "Settings"
+    },
+    "LogTab":
+    {
+        "message": "Log"
+    },
+    "NewsTab":
+    {
+        "message": "News"
+    },
+    "BulkDMTab":
+    {
+        "message": "Bulk DM"
+    },
+    "AIAssistantTab":
+    {
+        "message": "AI Assistant"
+    },
+    "MessagePlaceholder":
+    {
+        "message": "Hello!"
+    },
+    "ExternalUrlContainsPlaceholder":
+    {
+        "message": "youtube.com"
+    },
+    "ExternalUrlNotContainsPlaceholder":
+    {
+        "message": "onlyfans.com"
+    },
+    "EmailPlaceholder":
+    {
+        "message": "email@address.com"
+    },
+    "Last4Placeholder":
+    {
+        "message": "Last 4 digits of payment card"
+    },
+    "DmUsersPlaceholder":
+    {
+        "message": "user1, user2"
+    },
+    "DmMessagePlaceholder":
+    {
+        "message": "Your message"
+    },
+    "ApiKeyPlaceholder":
+    {
+        "message": "API key"
+    },
     "Followers":
     {
         "message": "Followers"

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -7,6 +7,74 @@
     {
         "message": "Automatic follow/unfollow/like with advanced filters, randomized timers, and more high-tech features."
     },
+    "AccountsQueueTab":
+    {
+        "message": "Cola de cuentas"
+    },
+    "MediaQueueTab":
+    {
+        "message": "Cola de medios"
+    },
+    "ActionsQueueTab":
+    {
+        "message": "Cola de acciones"
+    },
+    "FiltersTab":
+    {
+        "message": "Filtros"
+    },
+    "SettingsTab":
+    {
+        "message": "Configuración"
+    },
+    "LogTab":
+    {
+        "message": "Registro"
+    },
+    "NewsTab":
+    {
+        "message": "Noticias"
+    },
+    "BulkDMTab":
+    {
+        "message": "DM masivo"
+    },
+    "AIAssistantTab":
+    {
+        "message": "Asistente de IA"
+    },
+    "MessagePlaceholder":
+    {
+        "message": "¡Hola!"
+    },
+    "ExternalUrlContainsPlaceholder":
+    {
+        "message": "youtube.com"
+    },
+    "ExternalUrlNotContainsPlaceholder":
+    {
+        "message": "onlyfans.com"
+    },
+    "EmailPlaceholder":
+    {
+        "message": "correo@direccion.com"
+    },
+    "Last4Placeholder":
+    {
+        "message": "Últimos 4 dígitos de la tarjeta"
+    },
+    "DmUsersPlaceholder":
+    {
+        "message": "usuario1, usuario2"
+    },
+    "DmMessagePlaceholder":
+    {
+        "message": "Tu mensaje"
+    },
+    "ApiKeyPlaceholder":
+    {
+        "message": "Clave API"
+    },
     "Followers":
     {
         "message": "Followers"

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -435,6 +435,57 @@
    "appDesc": {
       "message": "Seguir/Deixar de Seguir/Curtir automático com filtros avançados, temporizadores aleatórios e mais recursos de alta tecnologia."
    },
+   "AccountsQueueTab": {
+      "message": "Fila de contas"
+   },
+   "MediaQueueTab": {
+      "message": "Fila de mídias"
+   },
+   "ActionsQueueTab": {
+      "message": "Fila de ações"
+   },
+   "FiltersTab": {
+      "message": "Filtros"
+   },
+   "SettingsTab": {
+      "message": "Configurações"
+   },
+   "LogTab": {
+      "message": "Registro"
+   },
+   "NewsTab": {
+      "message": "Notícias"
+   },
+   "BulkDMTab": {
+      "message": "DM em massa"
+   },
+   "AIAssistantTab": {
+      "message": "Assistente de IA"
+   },
+   "MessagePlaceholder": {
+      "message": "Olá!"
+   },
+   "ExternalUrlContainsPlaceholder": {
+      "message": "youtube.com"
+   },
+   "ExternalUrlNotContainsPlaceholder": {
+      "message": "onlyfans.com"
+   },
+   "EmailPlaceholder": {
+      "message": "email@endereco.com"
+   },
+   "Last4Placeholder": {
+      "message": "Últimos 4 dígitos do cartão"
+   },
+   "DmUsersPlaceholder": {
+      "message": "usuário1, usuário2"
+   },
+   "DmMessagePlaceholder": {
+      "message": "Sua mensagem"
+   },
+   "ApiKeyPlaceholder": {
+      "message": "Chave da API"
+   },
    "applyFiltersAutomatically": {
       "message": "Aplicar Filtros Automaticamente ao Seguir"
    },

--- a/_locales/pt_PT/messages.json
+++ b/_locales/pt_PT/messages.json
@@ -431,6 +431,57 @@
    "appDesc": {
       "message": "Seguir/Deixar de Seguir/Curtir automático com filtros avançados, temporizadores aleatórios e mais recursos de alta tecnologia."
    },
+   "AccountsQueueTab": {
+      "message": "Fila de contas"
+   },
+   "MediaQueueTab": {
+      "message": "Fila de mídia"
+   },
+   "ActionsQueueTab": {
+      "message": "Fila de ações"
+   },
+   "FiltersTab": {
+      "message": "Filtros"
+   },
+   "SettingsTab": {
+      "message": "Definições"
+   },
+   "LogTab": {
+      "message": "Registo"
+   },
+   "NewsTab": {
+      "message": "Notícias"
+   },
+   "BulkDMTab": {
+      "message": "DM em massa"
+   },
+   "AIAssistantTab": {
+      "message": "Assistente de IA"
+   },
+   "MessagePlaceholder": {
+      "message": "Olá!"
+   },
+   "ExternalUrlContainsPlaceholder": {
+      "message": "youtube.com"
+   },
+   "ExternalUrlNotContainsPlaceholder": {
+      "message": "onlyfans.com"
+   },
+   "EmailPlaceholder": {
+      "message": "email@endereço.com"
+   },
+   "Last4Placeholder": {
+      "message": "Últimos 4 dígitos do cartão"
+   },
+   "DmUsersPlaceholder": {
+      "message": "utilizador1, utilizador2"
+   },
+   "DmMessagePlaceholder": {
+      "message": "A sua mensagem"
+   },
+   "ApiKeyPlaceholder": {
+      "message": "Chave da API"
+   },
    "applyFiltersAutomatically": {
       "message": "Aplicar Filtros Automaticamente ao Seguir"
    },

--- a/contentscript.css
+++ b/contentscript.css
@@ -1583,11 +1583,17 @@ input.gridjs-search-input {
     list-style: none;
     margin: 0;
     padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2px;
+}
+
+.pc-tab ul li {
+    flex: 1 1 auto;
 }
 
 .pc-tab ul li label {
     cursor: pointer;
-    float: left;
     padding: 15px 25px;
     border: 1px solid #ddd;
     background-color: #eeeeee;
@@ -1595,6 +1601,8 @@ input.gridjs-search-input {
     background-size: 20px;
     background-repeat: no-repeat;
     background-position: 10px center;
+    display: block;
+    text-align: center;
 }
 
 .pc-tab ul li label[for="tab3"] {
@@ -1622,39 +1630,43 @@ input.gridjs-search-input {
 .pc-tab section {
     border-top: 1px solid #ddd;
     height: 95%;
-    clear: both;
+    display: flex;
+    flex-direction: column;
 }
 
 .pc-tab section>div {
     background: #fafafa;
-    /*padding: 20px;
-      width: 100%;
-      line-height: 1.5em;
-      letter-spacing: 0.3px;
-      color: #444;
-    */
+    width: 100%;
+    line-height: 1.5em;
+    letter-spacing: 0.3px;
+    color: #444;
+    padding: 20px;
 }
 
 #tab1:checked~section .tab1,
 #tab2:checked~section .tab2,
+#tab8:checked~section .tab8,
 #tab3:checked~section .tab3,
 #tab4:checked~section .tab4,
 #tab5:checked~section .tab5,
 #tab6:checked~section .tab6,
-#tab7:checked~section .tab7,
-#tab8:checked~section .tab8 {
-    display: block;
+#tab9:checked~section .tab9,
+#tab10:checked~section .tab10 {
+    display: flex;
+    flex-direction: column;
     height: 100%;
+    gap: 10px;
 }
 
 #tab1:checked~nav .tab1 label,
 #tab2:checked~nav .tab2 label,
+#tab8:checked~nav .tab8 label,
 #tab3:checked~nav .tab3 label,
 #tab4:checked~nav .tab4 label,
 #tab5:checked~nav .tab5 label,
 #tab6:checked~nav .tab6 label,
-#tab7:checked~nav .tab7 label,
-#tab8:checked~nav .tab8 label {
+#tab9:checked~nav .tab9 label,
+#tab10:checked~nav .tab10 label {
     background-color: #fafafa;
     border-bottom: 1px solid #fafafa;
     color: #111;
@@ -1663,12 +1675,13 @@ input.gridjs-search-input {
 
 #tab1:checked~nav .tab1 label:after,
 #tab2:checked~nav .tab2 label:after,
+#tab8:checked~nav .tab8 label:after,
 #tab3:checked~nav .tab3 label:after,
 #tab4:checked~nav .tab4 label:after,
 #tab5:checked~nav .tab5 label:after,
 #tab6:checked~nav .tab6 label:after,
-#tab7:checked~nav .tab7 label:after,
-#tab8:checked~nav .tab8 label:after {
+#tab9:checked~nav .tab9 label:after,
+#tab10:checked~nav .tab10 label:after {
     content: "";
     display: block;
     position: absolute;

--- a/contentscript.js
+++ b/contentscript.js
@@ -5311,6 +5311,13 @@ function localizeExtension() {
         }
     });
 
+    $('#igBotInjectedContainer [localePlaceholder]').each(function() {
+        var localeMessage = chrome.i18n.getMessage($(this).attr('localePlaceholder'));
+        if (localeMessage.length > 0) {
+            $(this).attr('placeholder', localeMessage);
+        }
+    });
+
     $('#igBotInjectedContainer [localeReplaceString]').each(function() {
         $(this).text($(this).text().replace($(this).attr('localeReplaceString'), chrome.i18n.getMessage($(this).attr('localeReplaceString').replace(/ /g, '_'))));
     });

--- a/growbot.html
+++ b/growbot.html
@@ -27,22 +27,20 @@
             <input id="tab4" type="radio" name="pct" />
             <input id="tab5" type="radio" name="pct" />
             <input id="tab6" type="radio" name="pct" />
-            <input id="tab7" type="radio" name="pct" />
             <input id="tab8" type="radio" name="pct" />
             <input id="tab9" type="radio" name="pct" />
             <input id="tab10" type="radio" name="pct" />
             <nav>
                 <ul>
-                    <li class="tab1"> <label for="tab1">Accounts Queue</label> </li>
-                    <li class="tab2"> <label for="tab2">Media Queue</label> </li>
-                    <li class="tab8"> <label for="tab8">Actions Queue</label> </li>
-                    <li class="tab3"> <label for="tab3">Filters</label> </li>
-                    <li class="tab4"> <label for="tab4">Settings</label> </li>
-                    <li class="tab5"> <label for="tab5">Log</label> </li>
-                    <li class="tab6"> <label for="tab6">News &amp; Updates</label> </li>
-                    <li class="tab7"> <label for="tab7">Help &amp; FAQ</label> </li>
-                    <li class="tab9"> <label for="tab9">Bulk DM</label> </li>
-                    <li class="tab10"> <label for="tab10">AI Assistant</label> </li>
+                    <li class="tab1"> <label for="tab1" localeMessage="AccountsQueueTab">Accounts Queue</label> </li>
+                    <li class="tab2"> <label for="tab2" localeMessage="MediaQueueTab">Media Queue</label> </li>
+                    <li class="tab8"> <label for="tab8" localeMessage="ActionsQueueTab">Actions Queue</label> </li>
+                    <li class="tab3"> <label for="tab3" localeMessage="FiltersTab">Filters</label> </li>
+                    <li class="tab4"> <label for="tab4" localeMessage="SettingsTab">Settings</label> </li>
+                    <li class="tab5"> <label for="tab5" localeMessage="LogTab">Log</label> </li>
+                    <li class="tab6"> <label for="tab6" localeMessage="NewsTab">News</label> </li>
+                    <li class="tab9"> <label for="tab9" localeMessage="BulkDMTab">Bulk DM</label> </li>
+                    <li class="tab10"> <label for="tab10" localeMessage="AIAssistantTab">AI Assistant</label> </li>
                 </ul>
             </nav>
             <section id="mainSection">
@@ -146,7 +144,7 @@
                                     </label>
                                     <label for="radioMessage" title="Send a direct message to each account">
                                         <input type="radio" id="radioMessage" name="queueAction" value="radioMessage" /> <span>Send Message</span>
-                                        <input type="text" id="txtMessageText" placeholder="Hello!" />
+                                        <input type="text" id="txtMessageText" placeholder="Hello!" localePlaceholder="MessagePlaceholder" />
                                     </label>
                                     <label for="radioGetMoreData" title="Gets more data about each account in queue: Private Status, Followers, Following, Post Count, etc">
                                         <input type="radio" id="radioGetMoreData" name="queueAction" value="radioGetMoreData">
@@ -328,12 +326,12 @@
                         <label for="cbFilterExternalUrlContains">
                             <input type="checkbox" id="cbFilterExternalUrlContains" />
                             <span localeMessage="ExternalUrlContainsText">Link in Bio Has</span>
-                            <input type="text" id="txtFilterExternalUrlContains" placeholder="youtube.com">
+                            <input type="text" id="txtFilterExternalUrlContains" placeholder="youtube.com" localePlaceholder="ExternalUrlContainsPlaceholder">
                         </label>
                         <label for="cbFilterExternalUrlNotContains">
                             <input type="checkbox" id="cbFilterExternalUrlNotContains" />
                             <span localeMessage="ExternalUrlNotContainsText">Link in Bio Does Not Have</span>
-                            <input type="text" id="txtFilterExternalUrlNotContains" placeholder="onlyfans.com">
+                            <input type="text" id="txtFilterExternalUrlNotContains" placeholder="onlyfans.com" localePlaceholder="ExternalUrlNotContainsPlaceholder">
                         </label>
                         <label for="cbFilterBioContains">
                             <input type="checkbox" id="cbFilterBioContains" />
@@ -391,8 +389,8 @@
                             <summary localeMessage="relinkSubscription">Re-link Subscription</summary>
                             <br>
                             <form id="formRelinkSubscription">
-                                <input type="text" id="email" name="email" placeholder="email@address.com" style="border:1px solid #666;"></input>
-                                <input type="text" id="last4" name="last4" placeholder="Last 4 digits of payment card" maxlength="4" style="border:1px solid #666;"></input>
+                                <input type="text" id="email" name="email" placeholder="email@address.com" localePlaceholder="EmailPlaceholder" style="border:1px solid #666;"></input>
+                                <input type="text" id="last4" name="last4" placeholder="Last 4 digits of payment card" localePlaceholder="Last4Placeholder" maxlength="4" style="border:1px solid #666;"></input>
                                 <select id="month" name="month">
                                     <option>CC Exp Month</option>
                                     <option value="01">01</option>
@@ -866,23 +864,11 @@
                         </p>
                     </details>
                 </div>
-                <div class="tab7">
-                    <div id="faqhelp">
-                        <iframe id="iframeFAQ" src="https://www.growbotforfollowers.com/index.php?faqonly=true"></iframe>
-                        <p>Please read the entire FAQ. If your question is not answered, contact me. Please include screenshots and the Log.</p>
-                        <p>
-                            <a href="https://www.growbotforfollowers.com/" target="_blank" id="iconHelp">https://www.growbotforfollowers.com</a>
-                            <a href="mailto:growbotautomator@gmail.com" id="iconEmail" class="growbotEmailLink">growbotautomator@gmail.com</a>
-                            <a href="https://www.youtube.com/@growbotautomator/videos" target="_blank" id="iconYoutube">https://www.youtube.com/@growbotautomator</a>
-                            <a href="https://www.instagram.com/therealgrowbot" target="_blank" id="iconInstagram">@therealgrowbot</a>
-                        </p>
-                    </div>
-                </div>
                 <div class="tab9">
                     <h3>Bulk Direct Message</h3>
                     <p>Enter Instagram usernames (one per line or separated by commas) and a message to send.</p>
-                    <textarea id="txtDmUsers" placeholder="user1, user2" style="width:100%;height:80px;"></textarea>
-                    <textarea id="txtDmMessage" placeholder="Your message" style="width:100%;height:80px;"></textarea>
+                    <textarea id="txtDmUsers" placeholder="user1, user2" localePlaceholder="DmUsersPlaceholder" style="width:100%;height:80px;"></textarea>
+                    <textarea id="txtDmMessage" placeholder="Your message" localePlaceholder="DmMessagePlaceholder" style="width:100%;height:80px;"></textarea>
                     <div class="igBotInjectedButton" id="btnSendBulkDM">Send DM</div>
                 </div>
                 <div class="tab10">
@@ -896,7 +882,7 @@
                             <option value="deepseek">DeepSeek</option>
                         </select>
                     </label>
-                    <label>API Key: <input type="text" id="txtAiApiKey" placeholder="API key" /></label>
+                    <label>API Key: <input type="text" id="txtAiApiKey" placeholder="API key" localePlaceholder="ApiKeyPlaceholder" /></label>
                     <div class="igBotInjectedButton" id="btnAiScan">Scan</div>
                     <div id="aiResults"></div>
                 </div>


### PR DESCRIPTION
## Summary
- Reorder navigation for clearer access to Accounts, Media, Actions, Filters, Settings, Log, News, Bulk DM, and AI Assistant
- Use flexbox to harmonize tab spacing and section layout; add locale-aware placeholders
- Add translation strings for new labels/placeholders across all locales and wire up placeholder localization in script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fb2887c5c83239398804f7097938f