### PR TITLE
feat: persist AI settings and improve scan UX

### DIFF
--- a/contentscript.js
+++ b/contentscript.js
@@ -5505,6 +5505,14 @@ function bindEvents() {
 
     $('#btnSendBulkDM').click(bulkDM);
     $('#btnAiScan').click(aiScan);
+    $('#btnSaveAiSettings').click(function() {
+        var provider = $('#aiProviderSetting').val();
+        var apiKey = $('#txtAiApiKeySetting').val();
+        saveAiSettings(provider, apiKey);
+        $('#aiProvider').val(provider);
+        $('#txtAiApiKey').val(apiKey);
+        outputMessage('AI settings saved');
+    });
     $(document).on('click', '.aiFollow', function() {
         chrome.runtime.sendMessage({ follow: { username: $(this).data('username') } });
     });
@@ -5512,11 +5520,22 @@ function bindEvents() {
         chrome.runtime.sendMessage({ unfollowUser: $(this).data('username') });
     });
     $(document).on('click', '.aiDM', function() {
-        var msg = prompt('Message to send', $('#txtDmMessage').val() || '');
-        if (msg) {
-            sendDirectMessage($(this).data('username'), msg);
-        }
+        var username = $(this).data('username');
+        $('#aiDmModal').data('username', username).show();
+        $('#aiDmText').val($('#txtDmMessage').val() || '');
     });
+    $('#aiDmSend').click(function() {
+        var username = $('#aiDmModal').data('username');
+        var msg = $('#aiDmText').val();
+        if (msg && username) {
+            sendDirectMessage(username, msg);
+        }
+        $('#aiDmModal').hide();
+    });
+    $('#aiDmCancel').click(function() {
+        $('#aiDmModal').hide();
+    });
+    loadAiSettings();
 
 
     if (getCurrentPageUsername() != '') {
@@ -8766,6 +8785,24 @@ function bulkDM() {
     });
 }
 
+function saveAiSettings(provider, apiKey) {
+    chrome.storage.local.set({
+        aiProvider: provider,
+        aiApiKey: apiKey
+    });
+}
+
+function loadAiSettings() {
+    chrome.storage.local.get(['aiProvider', 'aiApiKey'], function(data) {
+        var provider = data.aiProvider || 'openai';
+        var apiKey = data.aiApiKey || '';
+        $('#aiProvider').val(provider);
+        $('#aiProviderSetting').val(provider);
+        $('#txtAiApiKey').val(apiKey);
+        $('#txtAiApiKeySetting').val(apiKey);
+    });
+}
+
 async function aiScan() {
     var keyword = $('#txtAiKeyword').val();
     var provider = $('#aiProvider').val();
@@ -8774,6 +8811,7 @@ async function aiScan() {
         alert('Keyword and API key required');
         return;
     }
+    saveAiSettings(provider, apiKey);
     var url;
     var body = { messages: [{ role: 'user', content: 'List Instagram usernames related to ' + keyword + ' separated by commas.' }] };
     if (provider === 'openai') {
@@ -8795,12 +8833,24 @@ async function aiScan() {
             },
             body: JSON.stringify(body)
         });
+        if (!response.ok) {
+            var errorText = await response.text();
+            outputMessage('AI scan failed: ' + response.status + ' ' + response.statusText);
+            console.error('AI scan error', errorText);
+            return;
+        }
         var data = await response.json();
-        var text = data && data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content || '';
-        var usernames = text.split(/[\s,]+/).map(function(u) { return u.replace('@', '').trim(); }).filter(function(u) { return u; });
+        var text = data && data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content;
+        if (!text) {
+            outputMessage('AI scan failed: invalid response');
+            console.error('AI scan invalid response', data);
+            return;
+        }
+        var matches = text.match(/@?([A-Za-z0-9._]+)/g) || [];
+        var usernames = Array.from(new Set(matches.map(function(u) { return u.replace('@', '').trim(); })));
         renderAiResults(usernames);
     } catch (e) {
-        outputMessage('AI scan failed');
+        outputMessage('AI scan failed: ' + e.message);
         console.error(e);
     }
 }

--- a/growbot.html
+++ b/growbot.html
@@ -538,6 +538,22 @@
                                 </label>
                             </div>
                         </details>
+                        <details id="detailsAiSettings">
+                            <summary>AI Settings</summary>
+                            <div class="followOptions">
+                                <label for="aiProviderSetting">Provider:
+                                    <select id="aiProviderSetting">
+                                        <option value="openai">OpenAI</option>
+                                        <option value="openrouter">OpenRouter</option>
+                                        <option value="deepseek">DeepSeek</option>
+                                    </select>
+                                </label>
+                                <label for="txtAiApiKeySetting">API Key:
+                                    <input type="text" id="txtAiApiKeySetting" placeholder="API key" />
+                                </label>
+                                <div class="igBotInjectedButton" id="btnSaveAiSettings">Save AI Settings</div>
+                            </div>
+                        </details>
                         <details id="detailsQueueColumns">
                             <summary localeMessage="QueueColumnsOptions">Columns to Show in Queue and CSV Export *BETA*</summary>
                             <div class="followOptions" id="queueColumnsOptions"></div>
@@ -899,6 +915,11 @@
                     <label>API Key: <input type="text" id="txtAiApiKey" placeholder="API key" /></label>
                     <div class="igBotInjectedButton" id="btnAiScan">Scan</div>
                     <div id="aiResults"></div>
+                    <div id="aiDmModal" style="display:none;position:fixed;top:40%;left:40%;background:#fff;padding:10px;border:1px solid #666;z-index:1000;">
+                        <textarea id="aiDmText" style="width:250px;height:80px;"></textarea>
+                        <div class="igBotInjectedButton" id="aiDmSend">Send</div>
+                        <div class="igBotInjectedButton" id="aiDmCancel">Cancel</div>
+                    </div>
                 </div>
             </section>
         </div>


### PR DESCRIPTION
## Summary
- extract unique usernames with regex and handle API errors in AI scan
- store AI provider and key in chrome.storage with Settings editor
- swap prompt-based DM for a modal input

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fb286d10083238afddc05cdecfe4c