### PR TITLE
Extend tab navigation for new features and drop help page

### DIFF
--- a/contentscript.css
+++ b/contentscript.css
@@ -1641,8 +1641,9 @@ input.gridjs-search-input {
 #tab4:checked~section .tab4,
 #tab5:checked~section .tab5,
 #tab6:checked~section .tab6,
-#tab7:checked~section .tab7,
-#tab8:checked~section .tab8 {
+#tab8:checked~section .tab8,
+#tab9:checked~section .tab9,
+#tab10:checked~section .tab10 {
     display: block;
     height: 100%;
 }
@@ -1653,8 +1654,9 @@ input.gridjs-search-input {
 #tab4:checked~nav .tab4 label,
 #tab5:checked~nav .tab5 label,
 #tab6:checked~nav .tab6 label,
-#tab7:checked~nav .tab7 label,
-#tab8:checked~nav .tab8 label {
+#tab8:checked~nav .tab8 label,
+#tab9:checked~nav .tab9 label,
+#tab10:checked~nav .tab10 label {
     background-color: #fafafa;
     border-bottom: 1px solid #fafafa;
     color: #111;
@@ -1667,8 +1669,9 @@ input.gridjs-search-input {
 #tab4:checked~nav .tab4 label:after,
 #tab5:checked~nav .tab5 label:after,
 #tab6:checked~nav .tab6 label:after,
-#tab7:checked~nav .tab7 label:after,
-#tab8:checked~nav .tab8 label:after {
+#tab8:checked~nav .tab8 label:after,
+#tab9:checked~nav .tab9 label:after,
+#tab10:checked~nav .tab10 label:after {
     content: "";
     display: block;
     position: absolute;

--- a/growbot.html
+++ b/growbot.html
@@ -27,7 +27,6 @@
             <input id="tab4" type="radio" name="pct" />
             <input id="tab5" type="radio" name="pct" />
             <input id="tab6" type="radio" name="pct" />
-            <input id="tab7" type="radio" name="pct" />
             <input id="tab8" type="radio" name="pct" />
             <input id="tab9" type="radio" name="pct" />
             <input id="tab10" type="radio" name="pct" />
@@ -40,7 +39,6 @@
                     <li class="tab4"> <label for="tab4">Settings</label> </li>
                     <li class="tab5"> <label for="tab5">Log</label> </li>
                     <li class="tab6"> <label for="tab6">News &amp; Updates</label> </li>
-                    <li class="tab7"> <label for="tab7">Help &amp; FAQ</label> </li>
                     <li class="tab9"> <label for="tab9">Bulk DM</label> </li>
                     <li class="tab10"> <label for="tab10">AI Assistant</label> </li>
                 </ul>
@@ -75,7 +73,7 @@
                             <p>1. This is the <i>queue</i>. Use the Load button below to get some accounts to work on. </p>
                             <p>2. <i>Optional</i>: You can select, remove, whitelist, etc using the With Selection button</p>
                             <p>3. Use the "Process Queue" button to start following, unfollowing, liking etc.</p>
-                            <p>4. Please read the Help &amp; FAQ</p>
+                            <p>4. Please read the FAQ</p>
                             <p>5. If you experience any issues, <b>read the FAQ</b>, then please email <a href="mailto:growbotautomator@gmail.com" class="growbotEmailLink">growbotautomator@gmail.com</a></p>
                             <br>
                         </div>
@@ -865,18 +863,6 @@
                             <br> - add option to automatically save queue after each processed account
                         </p>
                     </details>
-                </div>
-                <div class="tab7">
-                    <div id="faqhelp">
-                        <iframe id="iframeFAQ" src="https://www.growbotforfollowers.com/index.php?faqonly=true"></iframe>
-                        <p>Please read the entire FAQ. If your question is not answered, contact me. Please include screenshots and the Log.</p>
-                        <p>
-                            <a href="https://www.growbotforfollowers.com/" target="_blank" id="iconHelp">https://www.growbotforfollowers.com</a>
-                            <a href="mailto:growbotautomator@gmail.com" id="iconEmail" class="growbotEmailLink">growbotautomator@gmail.com</a>
-                            <a href="https://www.youtube.com/@growbotautomator/videos" target="_blank" id="iconYoutube">https://www.youtube.com/@growbotautomator</a>
-                            <a href="https://www.instagram.com/therealgrowbot" target="_blank" id="iconInstagram">@therealgrowbot</a>
-                        </p>
-                    </div>
                 </div>
                 <div class="tab9">
                     <h3>Bulk Direct Message</h3>


### PR DESCRIPTION
## Summary
- add CSS rules for new tabs 9 and 10 and drop obsolete tab 7 references
- remove Help & FAQ tab and section from `growbot.html`
- keep navigation coherent after removing help tab

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fb28203108323b19bc11634e39bb3