### PR TITLE
Remove obsolete help tab

### DIFF
--- a/contentscript.css
+++ b/contentscript.css
@@ -1641,7 +1641,6 @@ input.gridjs-search-input {
 #tab4:checked~section .tab4,
 #tab5:checked~section .tab5,
 #tab6:checked~section .tab6,
-#tab7:checked~section .tab7,
 #tab8:checked~section .tab8 {
     display: block;
     height: 100%;
@@ -1653,7 +1652,6 @@ input.gridjs-search-input {
 #tab4:checked~nav .tab4 label,
 #tab5:checked~nav .tab5 label,
 #tab6:checked~nav .tab6 label,
-#tab7:checked~nav .tab7 label,
 #tab8:checked~nav .tab8 label {
     background-color: #fafafa;
     border-bottom: 1px solid #fafafa;
@@ -1667,7 +1665,6 @@ input.gridjs-search-input {
 #tab4:checked~nav .tab4 label:after,
 #tab5:checked~nav .tab5 label:after,
 #tab6:checked~nav .tab6 label:after,
-#tab7:checked~nav .tab7 label:after,
 #tab8:checked~nav .tab8 label:after {
     content: "";
     display: block;

--- a/growbot.html
+++ b/growbot.html
@@ -27,7 +27,6 @@
             <input id="tab4" type="radio" name="pct" />
             <input id="tab5" type="radio" name="pct" />
             <input id="tab6" type="radio" name="pct" />
-            <input id="tab7" type="radio" name="pct" />
             <input id="tab8" type="radio" name="pct" />
             <input id="tab9" type="radio" name="pct" />
             <input id="tab10" type="radio" name="pct" />
@@ -40,7 +39,6 @@
                     <li class="tab4"> <label for="tab4">Settings</label> </li>
                     <li class="tab5"> <label for="tab5">Log</label> </li>
                     <li class="tab6"> <label for="tab6">News &amp; Updates</label> </li>
-                    <li class="tab7"> <label for="tab7">Help &amp; FAQ</label> </li>
                     <li class="tab9"> <label for="tab9">Bulk DM</label> </li>
                     <li class="tab10"> <label for="tab10">AI Assistant</label> </li>
                 </ul>
@@ -865,18 +863,6 @@
                             <br> - add option to automatically save queue after each processed account
                         </p>
                     </details>
-                </div>
-                <div class="tab7">
-                    <div id="faqhelp">
-                        <iframe id="iframeFAQ" src="https://www.growbotforfollowers.com/index.php?faqonly=true"></iframe>
-                        <p>Please read the entire FAQ. If your question is not answered, contact me. Please include screenshots and the Log.</p>
-                        <p>
-                            <a href="https://www.growbotforfollowers.com/" target="_blank" id="iconHelp">https://www.growbotforfollowers.com</a>
-                            <a href="mailto:growbotautomator@gmail.com" id="iconEmail" class="growbotEmailLink">growbotautomator@gmail.com</a>
-                            <a href="https://www.youtube.com/@growbotautomator/videos" target="_blank" id="iconYoutube">https://www.youtube.com/@growbotautomator</a>
-                            <a href="https://www.instagram.com/therealgrowbot" target="_blank" id="iconInstagram">@therealgrowbot</a>
-                        </p>
-                    </div>
                 </div>
                 <div class="tab9">
                     <h3>Bulk Direct Message</h3>


### PR DESCRIPTION
## Summary
- remove Help & FAQ tab markup from growbot.html
- drop #tab7 references in contentscript.css

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fb279820c8323833ce1ff9cc6d2ab