### PR TITLE
feat(locale): add load accounts messages to French locale

### DIFF
--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -350,6 +350,15 @@
             }
         }
     },
+    "LoadAccounts":
+    {
+        "message": "Charger des comptes"
+    },
+    "LoadAccountsFromMediaQueue":
+    {
+        "message": "Charger des comptes depuis la file des médias",
+        "title": "Charge des comptes depuis la file des médias"
+    },
     "LoadPendingFollowRequests":
     {
         "message": "Charger les demandes d'abonnement en attente",


### PR DESCRIPTION
## Summary
- add missing French entries for `LoadAccounts` and `LoadAccountsFromMediaQueue`

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890cb4fed7c83238fa5a423a7083f91