### PR TITLE
feat: add basic theming with dark mode

### DIFF
--- a/contentscript.css
+++ b/contentscript.css
@@ -1,4 +1,4 @@
-/** 
+/**
  * Copyright (C) Growbot 2016-2023 - All Rights Reserved
  *
  * Unauthorized copying of this file, via any medium is strictly prohibited
@@ -6,6 +6,45 @@
  * Written by Growbot <growbotautomator@gmail.com>, 2016-2023
  */
 
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
+
+#igBotInjectedContainer {
+    --bg-color: #ffffff;
+    --text-color: #333333;
+    --primary-color: #1976d2;
+    --surface-color: #ffffff;
+    --border-color: #cccccc;
+    font-family: 'Inter', sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    color-scheme: light dark;
+}
+
+@media (prefers-color-scheme: dark) {
+    #igBotInjectedContainer {
+        --bg-color: #121212;
+        --text-color: #e0e0e0;
+        --primary-color: #90caf9;
+        --surface-color: #1e1e1e;
+        --border-color: #333333;
+    }
+}
+
+#igBotInjectedContainer.dark {
+    --bg-color: #121212;
+    --text-color: #e0e0e0;
+    --primary-color: #90caf9;
+    --surface-color: #1e1e1e;
+    --border-color: #333333;
+}
+
+#igBotInjectedContainer.light {
+    --bg-color: #ffffff;
+    --text-color: #333333;
+    --primary-color: #1976d2;
+    --surface-color: #ffffff;
+    --border-color: #cccccc;
+}
 
 @keyframes pulse {
     0% {
@@ -48,12 +87,10 @@ summary {
 }
 
 #igBotInjectedContainer * {
-    color: #333;
-    color-scheme: light;
+    color: var(--text-color);
 }
 
 #igBotInjectedContainer {
-    color: #333;
     margin: 0;
     padding: 0;
     border: 0;
@@ -61,8 +98,8 @@ summary {
     font: inherit;
     vertical-align: baseline;
     display: none;
-    background-color: #fafafa;
-    border: 1px solid #ccc;
+    background-color: var(--bg-color);
+    border: 1px solid var(--border-color);
     position: fixed;
     width: 98%;
     min-width: 260px;
@@ -226,19 +263,24 @@ summary {
 #igBotInjectedContainer .igBotInjectedButton {
     text-align: center;
     margin: 5px 0px;
-    border-radius: 3px;
-    color: white;
-    background-color: #2583cc;
-    font-family: 12pt Helvetica;
-    font-weight: bold;
+    border-radius: 8px;
+    color: var(--surface-color);
+    background-color: var(--primary-color);
+    font-family: inherit;
+    font-weight: 600;
     cursor: pointer;
     width: 100%;
-    padding: 8px 2px;
+    padding: 10px 16px;
+    transition: background-color 0.3s, opacity 0.3s;
+}
+
+#igBotInjectedContainer .igBotInjectedButton:hover:not(.inactive):not(.disabled) {
+    opacity: 0.9;
 }
 
 #igBotInjectedContainer #btnStop,
 #igBotInjectedContainer #btnStop2 {
-    background-color: red;
+    background-color: #e53935;
 }
 
 .igBotInjectedButton.disabled,
@@ -247,8 +289,8 @@ summary {
 .igBotInjectedButton.inactive,
 #igBotQueueContainerButtons .igBotInjectedButton.inactive,
 #igBotMediaButtonContainer .igBotInjectedButton.inactive {
-    background-color: #ccc;
-    color: #666;
+    background-color: var(--border-color);
+    color: var(--text-color);
     cursor: not-allowed;
 }
 
@@ -1749,4 +1791,40 @@ nav {
 
 .aiResult button {
     margin-left: 5px;
+}
+
+#igBotInjectedContainer {
+    background-color: var(--bg-color);
+    color: var(--text-color);
+}
+
+#igBotInjectedContainer input,
+#igBotInjectedContainer select,
+#igBotInjectedContainer textarea {
+    background-color: var(--surface-color);
+    color: var(--text-color);
+    border-color: var(--border-color);
+}
+
+#igBotInjectedContainer nav {
+    position: sticky;
+    top: 0;
+    background-color: var(--surface-color);
+}
+
+#igBotInjectedContainer nav ul {
+    display: flex;
+    flex-wrap: wrap;
+    margin: 0;
+    padding: 0;
+}
+
+#igBotInjectedContainer nav li {
+    list-style: none;
+    flex: 1;
+}
+
+#igBotInjectedContainer nav label {
+    display: block;
+    padding: 10px 12px;
 }

--- a/contentscript.js
+++ b/contentscript.js
@@ -1086,7 +1086,8 @@ var defaultOptions = {
     lastTab: 'tab1',
     includePinnedPostForLikes: true,
     includePinnedPostForComments: true,
-    messageToSend: ''
+    messageToSend: '',
+    theme: 'auto'
 };
 
 var gblOptions = defaultOptions;
@@ -1552,6 +1553,8 @@ function loadOptions() {
             document.getElementById('cbShowLikesInQueue').checked = gblOptions.showLikesInQueue;
             document.getElementById('cbShowQueueOnScreen').checked = gblOptions.cbShowQueueOnScreen;
             document.getElementById('cbRemoveUnusedColumns').checked = gblOptions.cbRemoveUnusedColumns;
+            document.getElementById('selectTheme').value = gblOptions.theme || 'auto';
+            applyTheme();
             document.getElementById('cbClickNotNow').checked = gblOptions.clickNotNow;
             document.getElementById('cbLoadQueueOnStartup').checked = gblOptions.loadQueueOnStartup;
             document.getElementById('cbLimitActions').checked = gblOptions.maxPerEnabled;
@@ -1678,6 +1681,17 @@ function setFilterIconOpacity() {
     }
 }
 
+function applyTheme() {
+    var container = document.getElementById('igBotInjectedContainer');
+    if (!container) return;
+    container.classList.remove('light', 'dark');
+    if (gblOptions.theme === 'dark') {
+        container.classList.add('dark');
+    } else if (gblOptions.theme === 'light') {
+        container.classList.add('light');
+    }
+}
+
 function saveOptions() {
 
     gblOptions.filterOptions.applyFiltersAutomatically = document.getElementById('cbApplyFilterAutomatically').checked;
@@ -1773,6 +1787,8 @@ function saveOptions() {
     gblOptions.includePinnedPostForLikes = document.getElementById('includePinnedPostForLikes').checked;
     gblOptions.includePinnedPostForComments = document.getElementById('includePinnedPostForComments').checked;
     gblOptions.messageToSend = document.getElementById('txtMessageText').value;
+    gblOptions.theme = document.getElementById('selectTheme').value;
+    applyTheme();
 
     document.querySelectorAll('#detailsQueueColumns input').forEach((cb) => {
         var columnDataName = cb.id.replace('cb_', '');

--- a/growbot.html
+++ b/growbot.html
@@ -387,6 +387,14 @@
                 <div class="tab4">
                     <div id="igBotOptions">
                         <h3 localeMessage="Settings">Settings</h3>
+                        <label for="selectTheme">Theme:
+                            <select id="selectTheme">
+                                <option value="auto">Auto</option>
+                                <option value="light">Light</option>
+                                <option value="dark">Dark</option>
+                            </select>
+                        </label>
+                        <br>
                         <details id="relinkSubscription">
                             <summary localeMessage="relinkSubscription">Re-link Subscription</summary>
                             <br>


### PR DESCRIPTION
## Summary
- modernize UI styling with CSS variables and Inter font
- add dark mode with auto/light/dark theme selector in Settings
- persist theme preference and apply dynamically

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689140efca588323aa6a5f6b8eb7f9d5