### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -59,6 +59,10 @@
     {
         "message": "Settings"
     },
+    "DarkMode":
+    {
+        "message": "Dark mode"
+    },
     "PerformanceOptions":
     {
         "message": "Performance Options"

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -59,6 +59,10 @@
     {
         "message": "Settings"
     },
+    "DarkMode":
+    {
+        "message": "Modo oscuro"
+    },
     "PerformanceOptions":
     {
         "message": "Performance Options"

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -59,6 +59,10 @@
     {
         "message": "Paramètres"
     },
+    "DarkMode":
+    {
+        "message": "Mode sombre"
+    },
     "PerformanceOptions":
     {
         "message": "Options de performance"

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -372,12 +372,15 @@
       "message": "Selecionar Nenhum",
       "title": "Não selecionar nada"
    },
-   "Settings": {
-      "message": "Configurações"
-   },
-   "Stop": {
-      "message": "Parar!"
-   },
+    "Settings": {
+        "message": "Configurações"
+    },
+    "DarkMode": {
+        "message": "Modo escuro"
+    },
+    "Stop": {
+        "message": "Parar!"
+    },
    "TimeDelay": {
       "message": "aguardando $time$ segundos",
       "placeholders": {

--- a/_locales/pt_PT/messages.json
+++ b/_locales/pt_PT/messages.json
@@ -371,12 +371,15 @@
       "message": "Selecionar Nenhum",
       "title": "Não selecionar nada"
    },
-   "Settings": {
-      "message": "Configurações"
-   },
-   "Stop": {
-      "message": "Parar!"
-   },
+    "Settings": {
+        "message": "Configurações"
+    },
+    "DarkMode": {
+        "message": "Modo escuro"
+    },
+    "Stop": {
+        "message": "Parar!"
+    },
    "TimeDelay": {
       "message": "aguardando $time$ segundos",
       "placeholders": {

--- a/contentscript.js
+++ b/contentscript.js
@@ -5291,6 +5291,7 @@ function injectControlsDiv() {
         loadPreviousAttempts();
         injectVersionNumber();
         loadActionsQueue();
+        initializeTheme();
 
 
         ready(igExternalVars.qsForConvenienceButtons, function(element) {
@@ -5336,6 +5337,34 @@ function buildMessagesJson() {
             alert($(this).attr('localeMessage'));
         }
     });
+}
+
+function initializeTheme() {
+    var container = document.getElementById('igBotInjectedContainer');
+    var toggle = document.getElementById('themeToggle');
+
+    function apply(mode) {
+        if (container) {
+            container.setAttribute('data-theme', mode);
+        }
+    }
+
+    chrome.storage.sync.get('theme', function(data) {
+        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        var mode = data.theme || (prefersDark ? 'dark' : 'light');
+        apply(mode);
+        if (toggle) {
+            toggle.checked = mode === 'dark';
+        }
+    });
+
+    if (toggle) {
+        toggle.addEventListener('change', function() {
+            var mode = toggle.checked ? 'dark' : 'light';
+            apply(mode);
+            chrome.storage.sync.set({ theme: mode });
+        });
+    }
 }
 
 (function(win) {

--- a/growbot.html
+++ b/growbot.html
@@ -387,6 +387,9 @@
                 <div class="tab4">
                     <div id="igBotOptions">
                         <h3 localeMessage="Settings">Settings</h3>
+                        <label for="themeToggle" style="display:block;margin:8px 0;">
+                            <input type="checkbox" id="themeToggle" /> <span localeMessage="DarkMode">Dark mode</span>
+                        </label>
                         <details id="relinkSubscription">
                             <summary localeMessage="relinkSubscription">Re-link Subscription</summary>
                             <br>

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
         },
         "content_scripts": [{
             "matches": ["https://*.instagram.com/*", "https://*.growbotforfollowers.com/*"],
-            "css": ["theme.blue.css", "contentscript.css", "jquery-ui.css"],
+            "css": ["theme.blue.css", "theme.css", "contentscript.css", "jquery-ui.css"],
             "js": ["jquery3.js", "jquery-ui.js", "wNumb.js", "nouislider.js", "jquery.tablesorter.js", "jquery.tablesorter.widgets.js", "widget-pager.js", "contentscript.js"],
             "run_at": "document_end",
             "all_frames": false

--- a/theme.css
+++ b/theme.css
@@ -1,0 +1,22 @@
+:root {
+  --igbot-bg: #ffffff;
+  --igbot-text: #111111;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --igbot-bg: #121212;
+    --igbot-text: #e0e0e0;
+  }
+}
+#igBotInjectedContainer {
+  background-color: var(--igbot-bg);
+  color: var(--igbot-text);
+}
+#igBotInjectedContainer[data-theme="light"] {
+  --igbot-bg: #ffffff;
+  --igbot-text: #111111;
+}
+#igBotInjectedContainer[data-theme="dark"] {
+  --igbot-bg: #121212;
+  --igbot-text: #e0e0e0;
+}


### PR DESCRIPTION
## Summary
- add theme.css with light/dark variables
- dark mode toggle in Settings saved to sync storage
- load new theme via manifest

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689145a3ed3c8323b1bc28a3baaa5271